### PR TITLE
Add Spotlight support

### DIFF
--- a/Emoji.plist
+++ b/Emoji.plist
@@ -19,5 +19,14 @@
 	</dict>
 	<key>DCSDictionaryManufacturerName</key>
 	<string>Matt Sephton https://github.com/gingerbeardman/Emojipedia/</string>
+	<key>DCSDictionaryLanguages</key>
+	<array>
+		<dict>
+			<key>DCSDictionaryIndexLanguage</key>
+			<string>en</string>
+			<key>DCSDictionaryDescriptionLanguage</key>
+			<string>en</string>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Starting with OS X 10.11, the (undocumented) `DCSDictionaryLanguages` key must be present for the dictionary to show up in spotlight searches like the stock dictionaries do. Took me a while (2 years…) until I figured this out (so recently, in fact, that I didn’t ship the corresponding [Dictionaries](https://dictionaries.io) update yet).

![screen shot 2016-07-20 at 20 27 36](https://cloud.githubusercontent.com/assets/145881/16998406/950003c2-4eb9-11e6-8e70-ef56a7bc14c7.png)
