### PR TITLE
Fix Look Up to show full definition

### DIFF
--- a/Emoji.css
+++ b/Emoji.css
@@ -97,3 +97,10 @@ ul.tags li:after {
 ul.tags li:last-child:after {
   content: ".";
 }
+
+html.apple_client-panel body {
+  margin-top: 0px;
+  margin-left: 1em;
+  margin-bottom: 0px;
+  margin-right: 1em;
+}

--- a/Emoji.css
+++ b/Emoji.css
@@ -22,6 +22,14 @@ h2 {
   font-weight: normal;
 }
 
+/* use much smaller size in Look Up to fit in space available for a definition */
+html.apple_client-panel h1 {
+  font-size: 2rem;
+}
+html.apple_client-panel h2 {
+  font-size: 1rem;
+}
+
 li {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
This fixes #5 by a) making the emoji itself as well as the description smaller and b) removing unwanted default padding. (You mentioned some time ago that changing size didn't work for you, but I think that was due to Look Up's *heavy* caching of pre-rendered definitions.)

End result fits comfortably and looks better due to more consistent spacing with other definitions, tested with multiple dictionaries and different emojis.

This is the state before, as described in #5:

![before](https://cloud.githubusercontent.com/assets/145881/25314141/85345f38-283e-11e7-9f07-57ed34ad2ae1.png)

After this PR:

![fixed](https://cloud.githubusercontent.com/assets/145881/25314148/a7fa27a0-283e-11e7-86d9-861de75019cf.png)
