### PR TITLE
Remove underline under emoji

### DIFF
--- a/Emoji.css
+++ b/Emoji.css
@@ -44,7 +44,7 @@ a:hover {
   text-decoration: underline;
 }
 
-h1, h1:hover {
+h1, h1 span:hover {
   text-decoration: none;
 }
 


### PR DESCRIPTION
In Dictionary.app of OS X 10.10.5 the emoji is underlined if you hover over it. This PR solve it.

(With `defaults write com.apple.Dictionary WebKitDeveloperExtras -bool true` it is possible to open a WebInspector in the app)