### PR TITLE
Make Emoji.xml valid XML

### DIFF
--- a/Emoji.xml
+++ b/Emoji.xml
@@ -92,7 +92,6 @@
 <d:entry id="1F604" d:title="Smiling Face With Open Mouth &amp; Smiling Eyes">
   <d:index d:value="😄"/>
   <d:index d:value="Smiling Face With Open Mouth &amp; Smiling Eyes" d:title="😄"/>
-  <d:index d:value="&amp;" d:title="😄"/>
   <d:index d:value="eye" d:title="😄"/>
   <d:index d:value="eyes" d:title="😄"/>
   <d:index d:value="face" d:title="😄"/>
@@ -114,7 +113,6 @@
 <d:entry id="1F605" d:title="Smiling Face With Open Mouth &amp; Cold Sweat">
   <d:index d:value="😅"/>
   <d:index d:value="Smiling Face With Open Mouth &amp; Cold Sweat" d:title="😅"/>
-  <d:index d:value="&amp;" d:title="😅"/>
   <d:index d:value="cold" d:title="😅"/>
   <d:index d:value="face" d:title="😅"/>
   <d:index d:value="mouth" d:title="😅"/>
@@ -136,7 +134,6 @@
 <d:entry id="1F606" d:title="Smiling Face With Open Mouth &amp; Closed Eyes">
   <d:index d:value="😆"/>
   <d:index d:value="Smiling Face With Open Mouth &amp; Closed Eyes" d:title="😆"/>
-  <d:index d:value="&amp;" d:title="😆"/>
   <d:index d:value="closed" d:title="😆"/>
   <d:index d:value="eyes" d:title="😆"/>
   <d:index d:value="face" d:title="😆"/>
@@ -667,7 +664,6 @@
 <d:entry id="1F61C" d:title="Face With Stuck-Out Tongue &amp; Winking Eye">
   <d:index d:value="😜"/>
   <d:index d:value="Face With Stuck-Out Tongue &amp; Winking Eye" d:title="😜"/>
-  <d:index d:value="&amp;" d:title="😜"/>
   <d:index d:value="eye" d:title="😜"/>
   <d:index d:value="face" d:title="😜"/>
   <d:index d:value="joke" d:title="😜"/>
@@ -690,7 +686,6 @@
 <d:entry id="1F61D" d:title="Face With Stuck-Out Tongue &amp; Closed Eyes">
   <d:index d:value="😝"/>
   <d:index d:value="Face With Stuck-Out Tongue &amp; Closed Eyes" d:title="😝"/>
-  <d:index d:value="&amp;" d:title="😝"/>
   <d:index d:value="closed" d:title="😝"/>
   <d:index d:value="eye" d:title="😝"/>
   <d:index d:value="eyes" d:title="😝"/>
@@ -1047,7 +1042,6 @@
 <d:entry id="1F630" d:title="Face With Open Mouth &amp; Cold Sweat">
   <d:index d:value="😰"/>
   <d:index d:value="Face With Open Mouth &amp; Cold Sweat" d:title="😰"/>
-  <d:index d:value="&amp;" d:title="😰"/>
   <d:index d:value="blue" d:title="😰"/>
   <d:index d:value="cold" d:title="😰"/>
   <d:index d:value="face" d:title="😰"/>
@@ -42893,12 +42887,12 @@
   <d:index d:value="Input Symbols" d:title="🔣"/>
   <d:index d:value="input" d:title="🔣"/>
   <d:index d:value="symbols" d:title="🔣"/>
-  <d:index d:value="〒♪&%" d:title="🔣"/>
+  <d:index d:value="〒♪&amp;%" d:title="🔣"/>
   <h1>🔣</h1>
   <h2>Input Symbols</h2>
   <ul class="tags">
   <li>input</li>
-  <li>〒♪&%</li>
+  <li>〒♪&amp;%</li>
   </ul>
   <p><a href="http://📙.la/🔣/">More at Emojipedia</a></p>
 </d:entry>
@@ -43985,7 +43979,6 @@
 <d:entry id="1F1E61F1EC" d:title="Antigua &amp; Barbuda">
   <d:index d:value="🇦🇬"/>
   <d:index d:value="Antigua &amp; Barbuda" d:title="🇦🇬"/>
-  <d:index d:value="&amp;" d:title="🇦🇬"/>
   <d:index d:value="antigua" d:title="🇦🇬"/>
   <d:index d:value="barbuda" d:title="🇦🇬"/>
   <d:index d:value="flag" d:title="🇦🇬"/>
@@ -44145,7 +44138,6 @@
 <d:entry id="1F1E71F1E6" d:title="Bosnia &amp; Herzegovina">
   <d:index d:value="🇧🇦"/>
   <d:index d:value="Bosnia &amp; Herzegovina" d:title="🇧🇦"/>
-  <d:index d:value="&amp;" d:title="🇧🇦"/>
   <d:index d:value="bosnia" d:title="🇧🇦"/>
   <d:index d:value="flag" d:title="🇧🇦"/>
   <d:index d:value="herzegovina" d:title="🇧🇦"/>
@@ -44741,7 +44733,6 @@
 <d:entry id="1F1EA1F1E6" d:title="Ceuta &amp; Melilla">
   <d:index d:value="🇪🇦"/>
   <d:index d:value="Ceuta &amp; Melilla" d:title="🇪🇦"/>
-  <d:index d:value="&amp;" d:title="🇪🇦"/>
   <d:index d:value="ceuta" d:title="🇪🇦"/>
   <d:index d:value="flag" d:title="🇪🇦"/>
   <d:index d:value="melilla" d:title="🇪🇦"/>
@@ -45098,7 +45089,6 @@
 <d:entry id="1F1EC1F1F8" d:title="South Georgia &amp; South Sandwich Islands">
   <d:index d:value="🇬🇸"/>
   <d:index d:value="South Georgia &amp; South Sandwich Islands" d:title="🇬🇸"/>
-  <d:index d:value="&amp;" d:title="🇬🇸"/>
   <d:index d:value="flag" d:title="🇬🇸"/>
   <d:index d:value="georgia" d:title="🇬🇸"/>
   <d:index d:value="islands" d:title="🇬🇸"/>
@@ -45178,7 +45168,6 @@
 <d:entry id="1F1ED1F1F2" d:title="Heard &amp; Mcdonald Islands">
   <d:index d:value="🇭🇲"/>
   <d:index d:value="Heard &amp; Mcdonald Islands" d:title="🇭🇲"/>
-  <d:index d:value="&amp;" d:title="🇭🇲"/>
   <d:index d:value="flag" d:title="🇭🇲"/>
   <d:index d:value="heard" d:title="🇭🇲"/>
   <d:index d:value="islands" d:title="🇭🇲"/>
@@ -45486,7 +45475,6 @@
 <d:entry id="1F1F01F1F3" d:title="St. Kitts &amp; Nevis">
   <d:index d:value="🇰🇳"/>
   <d:index d:value="St. Kitts &amp; Nevis" d:title="🇰🇳"/>
-  <d:index d:value="&amp;" d:title="🇰🇳"/>
   <d:index d:value="flag" d:title="🇰🇳"/>
   <d:index d:value="kitts" d:title="🇰🇳"/>
   <d:index d:value="nevis" d:title="🇰🇳"/>
@@ -46227,7 +46215,6 @@
 <d:entry id="1F1F51F1F2" d:title="St. Pierre &amp; Miquelon">
   <d:index d:value="🇵🇲"/>
   <d:index d:value="St. Pierre &amp; Miquelon" d:title="🇵🇲"/>
-  <d:index d:value="&amp;" d:title="🇵🇲"/>
   <d:index d:value="flag" d:title="🇵🇲"/>
   <d:index d:value="miquelon" d:title="🇵🇲"/>
   <d:index d:value="pierre" d:title="🇵🇲"/>
@@ -46488,7 +46475,6 @@
 <d:entry id="1F1F81F1EF" d:title="Svalbard &amp; Jan Mayen">
   <d:index d:value="🇸🇯"/>
   <d:index d:value="Svalbard &amp; Jan Mayen" d:title="🇸🇯"/>
-  <d:index d:value="&amp;" d:title="🇸🇯"/>
   <d:index d:value="flag" d:title="🇸🇯"/>
   <d:index d:value="jan" d:title="🇸🇯"/>
   <d:index d:value="mayen" d:title="🇸🇯"/>
@@ -46590,7 +46576,6 @@
 <d:entry id="1F1F81F1F9" d:title="S~ao Tom'e &amp; Pr'incipe">
   <d:index d:value="🇸🇹"/>
   <d:index d:value="São Tomé &amp; Príncipe" d:title="🇸🇹"/>
-  <d:index d:value="&amp;" d:title="🇸🇹"/>
   <d:index d:value="flag" d:title="🇸🇹"/>
   <d:index d:value="pr'incipe" d:title="🇸🇹"/>
   <d:index d:value="s~ao" d:title="🇸🇹"/>
@@ -46669,7 +46654,6 @@
 <d:entry id="1F1F91F1E8" d:title="Turks &amp; Caicos Islands">
   <d:index d:value="🇹🇨"/>
   <d:index d:value="Turks &amp; Caicos Islands" d:title="🇹🇨"/>
-  <d:index d:value="&amp;" d:title="🇹🇨"/>
   <d:index d:value="caicos" d:title="🇹🇨"/>
   <d:index d:value="flag" d:title="🇹🇨"/>
   <d:index d:value="islands" d:title="🇹🇨"/>
@@ -46819,7 +46803,6 @@
 <d:entry id="1F1F91F1F9" d:title="Trinidad &amp; Tobago">
   <d:index d:value="🇹🇹"/>
   <d:index d:value="Trinidad &amp; Tobago" d:title="🇹🇹"/>
-  <d:index d:value="&amp;" d:title="🇹🇹"/>
   <d:index d:value="flag" d:title="🇹🇹"/>
   <d:index d:value="tobago" d:title="🇹🇹"/>
   <d:index d:value="trinidad" d:title="🇹🇹"/>
@@ -46970,7 +46953,6 @@
 <d:entry id="1F1FB1F1E8" d:title="St. Vincent &amp; Grenadines">
   <d:index d:value="🇻🇨"/>
   <d:index d:value="St. Vincent &amp; Grenadines" d:title="🇻🇨"/>
-  <d:index d:value="&amp;" d:title="🇻🇨"/>
   <d:index d:value="flag" d:title="🇻🇨"/>
   <d:index d:value="grenadines" d:title="🇻🇨"/>
   <d:index d:value="st." d:title="🇻🇨"/>
@@ -47049,7 +47031,6 @@
 <d:entry id="1F1FC1F1EB" d:title="Wallis &amp; Futuna">
   <d:index d:value="🇼🇫"/>
   <d:index d:value="Wallis &amp; Futuna" d:title="🇼🇫"/>
-  <d:index d:value="&amp;" d:title="🇼🇫"/>
   <d:index d:value="flag" d:title="🇼🇫"/>
   <d:index d:value="futuna" d:title="🇼🇫"/>
   <d:index d:value="wallis" d:title="🇼🇫"/>

--- a/generator/index.php
+++ b/generator/index.php
@@ -18,7 +18,6 @@ foreach ($all_emoji as $single) {
 
   $title = str_replace(array('“','”','’'), array('\'','\'','\''), $title);
   $title = sentence_case($title);
-  $title = htmlspecialchars($title);
 
   $titleclean = iconv('UTF-8','ASCII//TRANSLIT',$title);;
 
@@ -36,20 +35,23 @@ foreach ($all_emoji as $single) {
 
   echo "$n:$id:$title:$titleclean\n";
 
+  $title = htmlspecialchars($title, ENT_XML1);
+  $titleclean = htmlspecialchars($titleclean, ENT_XML1);
+
   // if ($n == 2379) break; // debug
 
   $out[] = "<d:entry id=\"$id\" d:title=\"$titleclean\">";
   $out[] = "  <d:index d:value=\"$emoji\"/>";
   $out[] = "  <d:index d:value=\"$title\" d:title=\"$emoji\"/>";
   foreach ($keywords as $word) {
-    $out[] = "  <d:index d:value=\"$word\" d:title=\"$emoji\"/>";
+    $out[] = "  <d:index d:value=\"" . htmlspecialchars($word, ENT_XML1) . "\" d:title=\"$emoji\"/>";
   }
   $out[] = "  <h1>$emoji</h1>";
   $out[] = "  <h2>$title</h2>";
   // $out[] = "  <p>$unicode</p>";
   $out[] = "  <ul class=\"tags\">";
   foreach ($words_alias as $tag) {
-    $out[] = "  <li>$tag</li>";
+    $out[] = "  <li>" . htmlspecialchars($tag, ENT_XML1) . "</li>";
   }
   $out[] = "  </ul>";
   $out[] = "  <p><a href=\"http://📙.la/$emoji/\">More at Emojipedia</a></p>";

--- a/generator/index.php
+++ b/generator/index.php
@@ -22,7 +22,7 @@ foreach ($all_emoji as $single) {
 
   $titleclean = iconv('UTF-8','ASCII//TRANSLIT',$title);;
 
-  $words_title = explode(' ', str_replace(array(' - ','-','(',')'), array(' ',' ','',''), strtolower($titleclean)));
+  $words_title = explode(' ', str_replace(array(' - ','-',' & ','(',')'), array(' ',' ',' ','',''), strtolower($titleclean)));
   $words_alias = explode(' | ', str_replace(array('“','”'),'',$aliases));
   if ($aliases == '') {
     $words_alias = $previous_aliases;


### PR DESCRIPTION
Even after 1da08889 `Emoji.xml` was still not a valid XML file:

```
$ xmllint --noout Emoji.xml
Emoji.xml:42896: parser error : xmlParseEntityRef: no name
  <d:index d:value="〒♪&%" d:title="🔣"/>
                           ^
Emoji.xml:42901: parser error : xmlParseEntityRef: no name
  <li>〒♪&%</li>
             ^
$
```
(`xmllint` is a good way to ensure validity, BTW)

This PR fixes it by escaping everywhere and also removes pointless "&" `<d:index>` entries (which previously resulted in invalid XML too) as well as changes escaping to explicitly use XML entities only.